### PR TITLE
Add textlint / markdownlint / reviewdog lint setup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,47 @@
+name: Lint
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - '.textlintrc.json'
+      - '.markdownlint.jsonc'
+      - 'prh.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/lint.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  textlint:
+    name: textlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install
+      - uses: tsuyoshicho/action-textlint@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          level: warning
+          textlint_flags: "docs/**/*.md README.md"
+
+  markdownlint:
+    name: markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-markdownlint@v0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          level: warning
+          markdownlint_flags: "docs/**/*.md README.md"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+npm-debug.log
+.DS_Store

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,13 @@
+{
+  // Base: enable all rules, then relax what's noisy for Japanese tech docs.
+  "default": true,
+
+  // Line length: Japanese text doesn't wrap on byte-based limits cleanly.
+  "MD013": false,
+
+  // Allow inline HTML (needed for <details>, <br>, tables with merged cells, etc.).
+  "MD033": false,
+
+  // Allow the same sub-heading text under different parents (e.g. multiple "まとめ").
+  "MD024": { "siblings_only": true }
+}

--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -1,0 +1,15 @@
+{
+  "rules": {
+    "preset-ja-technical-writing": {
+      "sentence-length": {
+        "max": 120
+      },
+      "no-exclamation-question-mark": false,
+      "max-kanji-continuous-len": false
+    },
+    "preset-ja-spacing": true,
+    "prh": {
+      "rulePaths": ["./prh.yml"]
+    }
+  }
+}

--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -5,11 +5,23 @@
         "max": 120
       },
       "no-exclamation-question-mark": false,
+      "ja-no-weak-phrase": false,
       "max-kanji-continuous-len": false
     },
     "preset-ja-spacing": true,
+    "preset-jtf-style": {
+      "1.1.3.箇条書き": false,
+      "4.2.1.句点(。)と読点(、)": false,
+      "4.3.2.ピリオド(.)、カンマ(,)": false
+    },
+    "ja-hiragana-keishikimeishi": true,
+    "ja-hiragana-hojodoushi": true,
+    "ja-hiragana-fukushi": true,
     "prh": {
       "rulePaths": ["./prh.yml"]
     }
+  },
+  "filters": {
+    "comments": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,13 @@
   },
   "devDependencies": {
     "textlint": "^14.0.0",
-    "textlint-rule-preset-ja-technical-writing": "^10.0.0",
+    "textlint-filter-rule-comments": "^1.2.2",
+    "textlint-rule-ja-hiragana-fukushi": "^1.2.0",
+    "textlint-rule-ja-hiragana-hojodoushi": "^1.2.0",
+    "textlint-rule-ja-hiragana-keishikimeishi": "^1.2.0",
     "textlint-rule-preset-ja-spacing": "^2.0.0",
+    "textlint-rule-preset-ja-technical-writing": "^10.0.0",
+    "textlint-rule-preset-jtf-style": "^2.3.0",
     "textlint-rule-prh": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,10 +2,15 @@
   "name": "docs-claude-sample",
   "private": true,
   "scripts": {
-    "lint": "textlint 'docs/**/*.md' 'README.md'",
-    "lint:fix": "textlint --fix 'docs/**/*.md' 'README.md'"
+    "lint": "npm run lint:text && npm run lint:md",
+    "lint:fix": "npm run lint:text:fix && npm run lint:md:fix",
+    "lint:text": "textlint 'docs/**/*.md' 'README.md'",
+    "lint:text:fix": "textlint --fix 'docs/**/*.md' 'README.md'",
+    "lint:md": "markdownlint 'docs/**/*.md' 'README.md'",
+    "lint:md:fix": "markdownlint --fix 'docs/**/*.md' 'README.md'"
   },
   "devDependencies": {
+    "markdownlint-cli": "^0.39.0",
     "textlint": "^14.0.0",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-ja-hiragana-fukushi": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "docs-claude-sample",
+  "private": true,
+  "scripts": {
+    "lint": "textlint 'docs/**/*.md' 'README.md'",
+    "lint:fix": "textlint --fix 'docs/**/*.md' 'README.md'"
+  },
+  "devDependencies": {
+    "textlint": "^14.0.0",
+    "textlint-rule-preset-ja-technical-writing": "^10.0.0",
+    "textlint-rule-preset-ja-spacing": "^2.0.0",
+    "textlint-rule-prh": "^6.0.0"
+  }
+}

--- a/prh.yml
+++ b/prh.yml
@@ -1,0 +1,19 @@
+version: 1
+rules:
+  - expected: 生成AI
+    patterns:
+      - 生成系AI
+      - 生成系 AI
+  - expected: Google Workspace
+    patterns:
+      - /google\s*workspace/i
+  - expected: Claude Code
+    patterns:
+      - ClaudeCode
+      - /claude\s*code/
+  - expected: Gemini
+    patterns:
+      - /gemini/
+  - expected: Claude
+    patterns:
+      - /claude(?!\s*Code)/


### PR DESCRIPTION
## Summary
- textlint（preset-ja-technical-writing / preset-ja-spacing / preset-jtf-style / hiragana-*/ prh / comments filter）を導入
- markdownlint-cli と `.markdownlint.jsonc`（MD013/MD033 無効、MD024 を siblings_only）を追加
- `.github/workflows/lint.yml` で PR 時に textlint と markdownlint を **reviewdog** 経由で走らせ、警告を inline コメントとして残す（`level: warning` / `reporter: github-pr-review`）

## Commits
- `6eb99f0` Add textlint setup for Japanese technical writing
- `0600943` Expand textlint setup with tech-blog recommended rules
- `5588f89` Add markdownlint and reviewdog CI for docs

## Test plan
- [ ] PR 上で textlint / markdownlint ジョブが走り、警告が inline コメントとして表示されること
- [ ] ローカルで `npm install &amp;&amp; npm run lint` が通ること（preset や rule の整合性確認）
- [ ] `level: warning` なので警告があっても merge はブロックされないこと

## Follow-up
- ローカルで `npm install` 実行後に `package-lock.json` を commit すれば CI を `npm ci` に切り替えて高速化・再現性向上可
- 警告をハードに強制したい場合は `level: error` に変更