### PR TITLE
docs: 12章「対象読者と前提」の11章機能リストを11章本文と整合させる

### DIFF
--- a/docs/12-google-workspace-and-gemini.md
+++ b/docs/12-google-workspace-and-gemini.md
@@ -5,7 +5,7 @@
 ## 対象読者と前提
 
 - [1章](01-gemini-in-workspace.md)のハンズオンで、Docs／Gmailのサイドパネルを一度は触ったことがある
-- [8章](08-common-capabilities.md)の「チャット／アーティファクト／コネクタ」の3本柱と、[11章](11-gemini-advanced.md)で扱ったGemini固有機能（Gems・Deep Research・Canvas）にざっと目を通している
+- [8章](08-common-capabilities.md)の「チャット／アーティファクト／コネクタ」の3本柱と、[11章](11-gemini-advanced.md)で扱ったGemini固有機能（Gems・Canvas・マルチモーダル入力・画像生成・動画生成）にざっと目を通している
 - Google Workspaceを業務で普段使いしているが、Gemini連携の全体像はまだ断片的にしか触っていない
 
 Workspaceの各アプリは月単位でUIが更新されます。本章では画面のどこに何があるかをマニュアル的に並べるのではなく、どの場面で呼び出すと作業が進めやすいかを軸に整理します。ボタンの位置が動いても、場面ごとの使い分けそのものは大きく変わりません。


### PR DESCRIPTION
Closes #146

## 変更の要点

`docs/12-google-workspace-and-gemini.md` の「対象読者と前提」節（8行目）に書かれた、11章で扱う Gemini 固有機能のリストを、11章本文と整合させました。修正は1行のみです。

| 位置 | Before | After |
| ---- | ---- | ---- |
| 12-google-workspace-and-gemini.md L8 | Gems・Deep Research・Canvas | Gems・Canvas・マルチモーダル入力・画像生成・動画生成 |

## 整合方針

`docs/11-gemini-advanced.md` のリード（3行目）の現行表記は次のとおりです。

> 取り上げる機能は、Gems、Canvas、マルチモーダル入力、画像生成（Imagen）、動画生成（Veo）の5つです。

12章の該当行は「ざっと目を通している」前提を述べる箇条書きの一項目です。ここに5機能をすべて並べると箇条書きとしてはやや長くなりますが、Gems と Canvas の2つだけに絞ると11章本文との対応関係が読み手に取りにくくなるため、11章のリードに沿った5機能の並びに揃えました。

モデル名（Imagen／Veo）の括弧書きは、本行が「目を通している」前提の列挙であることに合わせて省きました。本文側で必要になる場面（12章 L100「挿絵の生成」節など）では、すでに `Imagen` の名称が使われており、参照経路は維持されています。

## 事前点検の結果

- 横断 grep を `docs/*.md` 全体に対して実施し、`Deep Research` のヒットが本ファイル8行目の1箇所のみであることを確認しました
- `docs/11-gemini-advanced.md` 本文に Deep Research の節は存在しないことを確認しました（過去版を含めた書き直し履歴でも未掲載）

## 確認方法

```bash
npm run lint
```

textlint・markdownlint ともにクリーンです。

## セルフレビュー

セルフレビューを1ラウンド実施し、修正点なしを確認しています。

- 中黒（`・`）と全角丸括弧の表記は本ファイルの既存スタイルと整合
- 5機能の並びは11章リードと同順
- 「ざっと目を通している」という前提語の射程に対し、5機能の列挙が過剰でないこと（モデル名の括弧書きは省略済み）

## 経緯

PR #141（11章の書き直し）の補足ノートで「12章の修正は別Issueでの対応が望ましい」と申し送りがあった内容を、本Issue／本PRで受けています。

## 関連

- 起票元：#146
- 参照PR：#141（11章書き直し）
- 関連ファイル：`docs/12-google-workspace-and-gemini.md`、`docs/11-gemini-advanced.md`