### PR TITLE
docs: 12章 Workspace Intelligence節のH2見出しを本文の語彙にそろえる

### DIFF
--- a/docs/12-google-workspace-and-gemini.md
+++ b/docs/12-google-workspace-and-gemini.md
@@ -32,7 +32,7 @@ flowchart LR
 
 同じ星形アイコンでも、入口が違えば会話の材料にできる対象も変わります。Docsなら本文、Gmailなら受信スレッド、Meetなら会議音声、という具合に、アプリで扱う素材がそのまま会話の前提になります。Workspaceサイドパネルの中心的な利点は、開いているファイルをコピー＆ペーストせずそのまま会話の材料として渡せる点です。
 
-## Workspace Intelligence: アプリ横断のsemantic layer
+## Workspace Intelligence: アプリ横断の意味的な層
 
 2026年4月のGoogle Cloud Next 2026で、Workspace向けの新しい仕組みとしてWorkspace Intelligenceが発表されました。Gmail・Docs・Drive・Meet・Chatで扱う素材を、ひとつの意味的な層として横断参照できるようにする位置づけです。アプリごとに別々に置かれていた素材（メール本文、ドキュメント本文、Drive上のファイル、Meetの議事録、Chatのスレッド）を、同じ会話の中でまとめて参照できる構成になっています。
 


### PR DESCRIPTION
## 背景

`docs/12-google-workspace-and-gemini.md` の H2 見出し `## Workspace Intelligence: アプリ横断のsemantic layer` だけが、章内の他の H2 と異なり英語混じり表記になっていました。同じ節の本文（L37）では `semantic layer` を「意味的な層」と日本語に開いて説明しているため、同じ概念を見出しと本文で2つの語彙で受け取る形になっていました。

12章は次のように、固有名詞 + 副題（日本語の用途語）のH2でそろえてあります。

```text
## サイドパネルから呼び出すGeminiの全体像
## Workspace Intelligence: アプリ横断のsemantic layer  ← ここだけ英語混じり
## Docs: 下書きから仕上げまで
## Sheets: 表を「読む」「作る」「直す」
## Gmail: 下書き、要約、整理
```

固有名詞 `Workspace Intelligence` はそのままに、副題の `semantic layer` だけを本文と同じ「意味的な層」に統一します。

## 変更点

- `docs/12-google-workspace-and-gemini.md` の H2 を `## Workspace Intelligence: アプリ横断の意味的な層` に変更
- 本文・参考URL・最終確認日はいずれも変更なし

## Test plan

- [x] `npm run lint` がエラー0件で通過する
- [x] 変更差分が H2 1 行のみで、本文の事実関係に変更が入っていない
- [x] 章内の他の H2 と副題の語彙が整合している

closes #202


---
_Generated by [Claude Code](https://claude.ai/code/session_019rPxEzexV2Sx5YfDgHvwKQ)_