### PR TITLE
docs: 02章・07章 推論モデル節のClaude側にOpus 4.7 / adaptive thinkingを反映する

### DIFF
--- a/docs/02-what-is-generative-ai.md
+++ b/docs/02-what-is-generative-ai.md
@@ -126,7 +126,7 @@ flowchart LR
 | 費用（API利用時） | 入出力トークン分のみ | 内部の思考分のトークンも課金対象になりやすい |
 | 得意になりやすい題材 | 要約、言い換え、定型の下書き | 多段の数学、コード生成、厳密な手順の組み立て |
 
-呼び名はプロバイダ・モデルごとに異なります。Claudeでは `extended thinking`、Geminiでは `Deep Think`、OpenAI系では `o`系列の推論モデルというように、表記はそろっていません。これらはいずれも同じ系統の機能を指しており、社内資料や外部記事の比較もこの対応関係に立って書かれています。Gemini側の具体例としては、2026年2月にリリースされた **Gemini 3 Deep Think** がGoogle AI Ultraサブスクで利用でき、現行世代の代表例として挙げられます（最終確認：2026-05-16）。各社のモデル並びでの位置づけは[11章](11-gemini-advanced.md)・[13章](13-claude.md)で扱います。
+呼び名はプロバイダ・モデルごとに異なります。Claudeでは `extended thinking`、Geminiでは `Deep Think`、OpenAI系では `o`系列の推論モデルというように、表記はそろっていません。これらはいずれも同じ系統の機能を指しており、社内資料や外部記事の比較もこの対応関係に立って書かれています。Gemini側の具体例としては、2026年2月にリリースされた **Gemini 3 Deep Think** がGoogle AI Ultraサブスクで利用でき、現行世代の代表例として挙げられます（最終確認：2026-05-16）。Claude側の具体例としては、2026年4月にGAされた **Claude Opus 4.7** が現行世代の代表例にあたり、`adaptive thinking` の方式に切り替わっています（最終確認：2026-05-16）。各社のモデル並びでの位置づけは[11章](11-gemini-advanced.md)・[13章](13-claude.md)で扱います。
 
 業務での使い分けの目安は、定型作業や下書きには通常モード、複数の条件をたどる検証や厳密な手順の組み立てには推論モード、という分け方です。費用と所要時間が増える分、すべての依頼を推論モードに切り替える必要はありません。
 
@@ -166,3 +166,4 @@ flowchart LR
 - Google「About large language models」: <https://ai.google.dev/gemini-api/docs/models>（最終確認：2026-04-24）
 - Google Cloud「What is Generative AI?」: <https://cloud.google.com/use-cases/generative-ai>（最終確認：2026-04-24）
 - Google Blog「Gemini 3 Deep Think: Advancing science, research and engineering」: <https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-deep-think/>（最終確認：2026-05-16）
+- Anthropic「Adaptive thinking」: <https://docs.claude.com/en/docs/build-with-claude/adaptive-thinking>（最終確認：2026-05-16）

--- a/docs/07-terminology.md
+++ b/docs/07-terminology.md
@@ -98,11 +98,11 @@
 
 | プロバイダ／モデル | 呼び方の例 |
 | ---- | ---- |
-| Anthropic（Claude） | extended thinking |
+| Anthropic（Claude） | extended thinking／adaptive thinking（Opus 4.7） |
 | Google（Gemini） | Deep Think（Gemini 3） |
 | OpenAI | `o`系列などの推論モデル |
 
-業界全体としては、推論モデル／思考モードという呼び方が定着しつつあります。記事や社内資料に並ぶ各社の呼称は、いずれも同じ系統の機能を指しており、各社の比較記事もこの対応関係に立って書かれています。Gemini側の世代名については、2026年2月にリリースされたGemini 3 Deep Thinkが現時点の具体例にあたります（最終確認：2026-05-16）。具体的なモデル並びでの位置づけは[11章](11-gemini-advanced.md)・[13章](13-claude.md)で扱います。
+業界全体としては、推論モデル／思考モードという呼び方が定着しつつあります。記事や社内資料に並ぶ各社の呼称は、いずれも同じ系統の機能を指しており、各社の比較記事もこの対応関係に立って書かれています。Gemini側の世代名については、2026年2月にリリースされたGemini 3 Deep Thinkが現時点の具体例にあたります（最終確認：2026-05-16）。Claude側では、2026年4月にGAされたClaude Opus 4.7が現時点の具体例にあたり、`adaptive thinking` の方式に切り替わっています（最終確認：2026-05-16）。具体的なモデル並びでの位置づけは[11章](11-gemini-advanced.md)・[13章](13-claude.md)で扱います。
 
 ## エージェント
 
@@ -147,3 +147,4 @@
 - Anthropic「Models overview」: <https://docs.anthropic.com/en/docs/about-claude/models>（最終確認：2026-04-24）
 - Google「Gemini models」: <https://ai.google.dev/gemini-api/docs/models>（最終確認：2026-04-24）
 - Google DeepMind「Gemini 3.1 Deep Think」: <https://deepmind.google/models/gemini/deep-think/>（最終確認：2026-05-16）
+- Anthropic「Adaptive thinking」: <https://docs.claude.com/en/docs/build-with-claude/adaptive-thinking>（最終確認：2026-05-16）


### PR DESCRIPTION
Closes #208

## 変更の要点

PR #196 で02章・07章・11章の推論モデル節にGemini 3 Deep Thinkの世代名と具体例を反映し、PR #197 で13章・付録デスクトップ自動化にClaude Opus 4.7（adaptive thinking）を反映しました。結果として、02章と07章の推論モデル節は Gemini 側の現行世代だけが書かれ、Claude 側は古い `extended thinking` のみが記載されている、という非対称な状態になっていました。

本PRでは、13章 L181 と11章 L93 の表現に語彙と粒度をそろえる形で、02章と07章の推論モデル節に Claude 側の現行世代（Opus 4.7 / adaptive thinking）の具体例を1文ずつ補い、両章の参考節に Anthropic「Adaptive thinking」を追加します。

### `docs/02-what-is-generative-ai.md`

- 「呼び名はプロバイダ・モデルごとに異なります」段落の末尾近くに、Gemini 側の具体例の直後で Claude 側の具体例（Opus 4.7 / adaptive thinking）を1文添える
- 参考節に Anthropic「Adaptive thinking」を追加

### `docs/07-terminology.md`

- 各社の呼称表（プロバイダ／モデル → 呼び方の例）の Anthropic 行を `extended thinking／adaptive thinking（Opus 4.7）` の併記に整える
- 表直下の補足文に、Gemini 側の現行世代の例に続けて Claude 側の現行世代の例も1文追加
- 参考節に Anthropic「Adaptive thinking」を追加

## 触らなかった範囲

- 章本文の論旨・章構成・節タイトル
- 11章・13章・付録デスクトップ自動化（すでに反映済み）
- ベンチマーク数値、内部実装、`xhigh` の細かい挙動（02章・07章は概念整理の章のため、利用者向けの輪郭にとどめる）
- 既存の参考URLの最終確認日（参考URLの妥当性に影響しない編集のため、`WRITING_GUIDE.md` の更新ルールに従い動かしていません）

## 確認方法

- `npm run lint` がパス（新規警告なし）
- 02章 L129・07章 L99-L105 を読んだだけで、Gemini 側と Claude 側の現行世代の対応関係が把握できること
- 13章 L181・11章 L93 の表現と、語彙・粒度（GA時期・モデル名・方式名・最終確認日）が揃っていること

## 一次ソース

- Anthropic「Adaptive thinking」: <https://docs.claude.com/en/docs/build-with-claude/adaptive-thinking>


---
_Generated by [Claude Code](https://claude.ai/code/session_01PGFCb8gMvqi1putH7NP6E1)_