### PR TITLE
docs: 12章「対象読者と前提」のGemini in Chrome行を11章への参照に集約する

### DIFF
--- a/docs/12-google-workspace-and-gemini.md
+++ b/docs/12-google-workspace-and-gemini.md
@@ -5,8 +5,7 @@
 ## 対象読者と前提
 
 - [1章](01-gemini-in-workspace.md)のハンズオンで、Docs／Gmailのサイドパネルを一度は触ったことがある
-- [8章](08-common-capabilities.md)の「チャット／アーティファクト／コネクタ」の3本柱と、[11章](11-gemini-advanced.md)で扱ったGemini固有機能（Gems・Canvas・マルチモーダル入力・画像生成・動画生成）にざっと目を通している
-- [11章](11-gemini-advanced.md)で扱ったGemini in Chrome（Chromeブラウザに組み込まれたGemini）にも一度触れている
+- [8章](08-common-capabilities.md)の「チャット／アーティファクト／コネクタ」の3本柱と、[11章](11-gemini-advanced.md)で扱ったGemini固有機能（Gems・Canvas・マルチモーダル入力・画像生成・動画生成）およびGemini in Chromeにざっと目を通している
 - Google Workspaceを業務で普段使いしているが、Gemini連携の全体像はまだ断片的にしか触っていない
 
 Workspaceの各アプリは月単位でUIが更新されます。本章では画面のどこに何があるかをマニュアル的に並べるのではなく、どの場面で呼び出すと作業が進めやすいかを軸に整理します。ボタンの位置が動いても、場面ごとの使い分けそのものは大きく変わりません。


### PR DESCRIPTION
Closes #218

## 概要

`docs/12-google-workspace-and-gemini.md`「対象読者と前提」の3行目（Gemini in Chrome）を独立した行から外し、2行目（8章・11章 Gemini固有機能への参照）に並列で組み込みました。本文・他章・参考節には触っていません。

## 変更内容

`docs/12-google-workspace-and-gemini.md` の「対象読者と前提」2-3行目（L8-L9）を1行に集約しています。

```diff
- - [8章](08-common-capabilities.md)の「チャット／アーティファクト／コネクタ」の3本柱と、[11章](11-gemini-advanced.md)で扱ったGemini固有機能（Gems・Canvas・マルチモーダル入力・画像生成・動画生成）にざっと目を通している
- - [11章](11-gemini-advanced.md)で扱ったGemini in Chrome（Chromeブラウザに組み込まれたGemini）にも一度触れている
+ - [8章](08-common-capabilities.md)の「チャット／アーティファクト／コネクタ」の3本柱と、[11章](11-gemini-advanced.md)で扱ったGemini固有機能（Gems・Canvas・マルチモーダル入力・画像生成・動画生成）およびGemini in Chromeにざっと目を通している
```

## 整合の確認

修正後の構造を、11章本文のリード（L3）と並べると対応関係が成立します。

| 位置 | 表現 |
| ---- | ---- |
| 11章リード（L3） | Gems、Canvas、マルチモーダル入力、画像生成（Imagen）、動画生成（Veo）の5つの機能と、Chromeブラウザに組み込まれた呼び出し口であるGemini in Chrome |
| 12章「対象読者と前提」（修正後） | Gemini固有機能（Gems・Canvas・マルチモーダル入力・画像生成・動画生成）およびGemini in Chrome |

加えて、12章の「対象読者と前提」内で `[11章]` が2行に分かれて重複していた状態が解消され、参照先の章ごとに1行に集約される箇条書きの並びになりました。13章 L9-L11 の「対象読者と前提」が8章・11章・12章への参照を1行に1章ずつ集約している型と並べて読めます。

## 触らなかった範囲

- 12章の本文・「まとめ」・「次は」節
- 11章本文（すでに整合がとれているため）
- 「対象読者と前提」の1行目・4行目（1章ハンズオン参照とWorkspace普段使いの条件）
- 参考節と最終確認日（参考URLの妥当性に影響しない編集のため、`WRITING_GUIDE.md`「最終確認日の更新ルール」に従い触っていません）

## 確認方法

- [x] `npm run lint` がエラー0件で通る
- [x] 12章「対象読者と前提」が、11章への参照を1行に集約した形になっている
- [x] 11章リードの並列構造（5機能＋Gemini in Chrome）と、12章「対象読者と前提」のリストで対応関係が読み取れる
- [x] 修正後の動詞が「ざっと目を通している」で揃っている

## 関連

- Issue: #218
- 同型の章間整合の前例：Issue #146 / PR #147（11章機能リスト整合の取りこぼし修正）
- PR #171（11章にGemini in Chromeの節を追加、Issue #169）
- 親ガイド：`WRITING_GUIDE.md`「章の骨格テンプレート」

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4thXMQvn6bsH7iK4hGJJt)_