### PR TITLE
docs: 5章・6章・7章の章末に次章への橋渡し文を追加

### DIFF
--- a/docs/05-misunderstanding-learning.md
+++ b/docs/05-misunderstanding-learning.md
@@ -121,6 +121,8 @@ sequenceDiagram
 - 入力データが学習に使われるかどうかは、API・ビジネスUI・個人UIのどの経路を使うかで既定値が違う。プランごとに公式ドキュメントを確認する
 - 「学習」と「履歴・メモリの保存」は別問題として扱う。消去すべき対象が変わる
 
+次は[6章（ハルシネーション）](06-hallucination-and-knowledge-literacy.md)で、モデルが「知らないこと」をもっともらしく出力してしまう現象と、その見分け方・対処に進みます。
+
 ## 参考
 
 - Anthropic「Privacy Policy」: <https://www.anthropic.com/legal/privacy>（最終確認：2026-04-24）

--- a/docs/06-hallucination-and-knowledge-literacy.md
+++ b/docs/06-hallucination-and-knowledge-literacy.md
@@ -176,6 +176,8 @@ sequenceDiagram
 - 出力の裏取りは利用者の責任であり、対外署名・社内資料・下書き・発想の4階層で配分する
 - 依頼に「根拠の明示／棄権の許容／範囲の限定」を加えると、誤りの発生率を下げられる
 
+次は[7章（用語集）](07-terminology.md)で、ここまでの章に登場した用語の定義を一覧で整理します。
+
 ## 参考
 
 - Anthropic「Claude models overview」: <https://docs.anthropic.com/en/docs/about-claude/models>（最終確認：2026-04-24）

--- a/docs/07-terminology.md
+++ b/docs/07-terminology.md
@@ -142,6 +142,8 @@
 - プロンプトとコンテキストはセットで定義が決まるため、ペアで参照すると意味の輪郭が安定する
 - トークンは課金・上限のいずれにも基準として使われ、料金と入力サイズの話題で参照される
 
+次は[8章（生成AIでできること 共通編）](08-common-capabilities.md)で、ここまでの用語を前提に、ClaudeとGeminiが共通して提供する能力をチャット・アーティファクト・コネクタの3本柱として整理します。
+
 ## 参考
 
 - Anthropic「Models overview」: <https://docs.anthropic.com/en/docs/about-claude/models>（最終確認：2026-04-24）


### PR DESCRIPTION
## 概要

本編1〜13章のうち、5章・6章・7章だけが「まとめ」節の後に次章への橋渡し文を持っていませんでした。他の章（1〜4章・8〜13章）はすべて「次は[N章](NN-...md)で、〜に進みます。」の形で次章への導線を置いており、5〜7章だけが読者の移動先を示さない区間になっていました。

本PRでは3章それぞれに橋渡し文を1文ずつ追加し、章末構造を他章と揃えます。

## 変更内容

- `docs/05-misunderstanding-learning.md` — 6章（ハルシネーション）への橋渡し文を追加
- `docs/06-hallucination-and-knowledge-literacy.md` — 7章（用語集）への橋渡し文を追加
- `docs/07-terminology.md` — 8章（共通編）への橋渡し文を追加

## 確認事項

- [x] `npm run lint`（textlint + markdownlint）エラー0件
- [x] 橋渡し文のmarkdownリンクが正しいファイルを指している
- [x] 他章の橋渡し文と文体・粒度が揃っている
- [x] まとめの箇条書き・参考節・本文の構成には触れていない

Closes #226

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vjhkg7dDzPyx2KNNoWmqcB)_