### PR TITLE
docs: 0章のおすすめ順路テーブルの章参照をリンク化し、付録紹介文を更新する

### DIFF
--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -66,15 +66,15 @@ flowchart TB
 
 | 目的 | おすすめ順路 |
 | ---- | ---- |
-| まず使ってみたい | 1章 → 8章 → （関心に応じて11章または13章） |
-| 依頼の出し方を上達させたい | 8章 → 付録「プロンプトの組み立て方」→ 11章または13章 |
-| 社内導入の判断材料がほしい | 2章 → 5章 → 9章 → 10章 |
-| エージェントで自動化を始めたい | 4章 → 7章 → 10章 → 付録「Claude Code」 |
-| 画像・PDF・音声をAIに扱わせたい | 3章 → 8章 → （関心に応じて11章または13章） |
+| まず使ってみたい | [1章](01-gemini-in-workspace.md) → [8章](08-common-capabilities.md) → （関心に応じて[11章](11-gemini-advanced.md)または[13章](13-claude.md)） |
+| 依頼の出し方を上達させたい | [8章](08-common-capabilities.md) → [付録「プロンプトの組み立て方」](appendix-prompting.md) → [11章](11-gemini-advanced.md)または[13章](13-claude.md) |
+| 社内導入の判断材料がほしい | [2章](02-what-is-generative-ai.md) → [5章](05-misunderstanding-learning.md) → [9章](09-security-individual.md) → [10章](10-security-agent-era.md) |
+| エージェントで自動化を始めたい | [4章](04-external-system-integration.md) → [7章](07-terminology.md) → [10章](10-security-agent-era.md) → [付録「Claude Code」](appendix-claude-code.md) |
+| 画像・PDF・音声をAIに扱わせたい | [3章](03-multimodal.md) → [8章](08-common-capabilities.md) → （関心に応じて[11章](11-gemini-advanced.md)または[13章](13-claude.md)） |
 
 付録6本は、本編から少し離れた領域を扱います。並びは、日常業務寄り→開発寄り→技術解説寄りの順です。
 
-- [プロンプトの組み立て方](appendix-prompting.md) — 依頼文の基本形と業務シーン別テンプレートに加え、カスタム指示（Gems・Projects）の書き方と、応答がずれたときの立て直しパターン
+- [プロンプトの組み立て方](appendix-prompting.md) — 依頼文の基本形と業務シーン別テンプレート、カスタム指示（Gems・Projects）の書き方、応答の立て直しパターンに加え、長い作業を複数の会話に分けて進めるときの引き継ぎ方
 - [ワークフローツール](appendix-workflow-tools.md) — ZapierやMake、n8nといったSaaS連携のノーコードツールに生成AIを組み込むときの観点
 - [デスクトップの自動化](appendix-desktop-automation.md) — 自席のPC上で繰り返している手作業を生成AIに任せる選択肢の整理
 - [Claude Code](appendix-claude-code.md) — 利用者のPC上で動くClaude製品の位置づけと、ブラウザ版との違い、最初の運用方針の整理


### PR DESCRIPTION
## 概要

0章（オーバービュー）の「おすすめ順路」テーブルと付録紹介文を更新します。

## 変更内容

### 系統A: おすすめ順路テーブルのリンク化

テーブル5行に含まれる章参照（延べ17箇所）と付録参照（2箇所）を、すべてmarkdownリンクに置き換えました。読者がテーブルから目的の章へ直接遷移できるようになります。

#220（08章）、#224（02・10・12・13章）、#246（0章の付録一覧）で章参照のリンク化が系統的に進められてきましたが、0章の最重要ナビゲーション要素であるおすすめ順路テーブルだけが射程外として残っていました。

### 系統B: 付録「プロンプトの組み立て方」の紹介文更新

#270で追加された「長い作業を複数の会話に分けて進める」節への言及を、付録紹介文に追記しました。#268で紹介文を更新した後に#270の節追加があったため、0章の記述が実態に追いついていない状態でした。

## 触らなかった範囲

- テーブルの行数・列構成・目的の文言
- 付録一覧の他の5項目の紹介文
- 本文の論旨・節構成・参考節

## 確認事項

- [x] `npm run lint` クリーン
- [x] リンク先のファイル名がすべて実在のファイルと一致している

Closes #276

---
_Generated by [Claude Code](https://claude.ai/code/session_01PabE6saFJUQ3YFDxwquKn2)_