### PR TITLE
docs: 0章のおすすめ順路に12章を追加し、Workspace活用ルートを新設する

### DIFF
--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -66,11 +66,12 @@ flowchart TB
 
 | 目的 | おすすめ順路 |
 | ---- | ---- |
-| まず使ってみたい | [1章](01-gemini-in-workspace.md) → [8章](08-common-capabilities.md) → （関心に応じて[11章](11-gemini-advanced.md)または[13章](13-claude.md)） |
-| 依頼の出し方を上達させたい | [8章](08-common-capabilities.md) → [付録「プロンプトの組み立て方」](appendix-prompting.md) → [11章](11-gemini-advanced.md)または[13章](13-claude.md) |
+| まず使ってみたい | [1章](01-gemini-in-workspace.md) → [8章](08-common-capabilities.md) → （Geminiなら[11章](11-gemini-advanced.md)・[12章](12-google-workspace-and-gemini.md)、Claudeなら[13章](13-claude.md)） |
+| 依頼の出し方を上達させたい | [8章](08-common-capabilities.md) → [付録「プロンプトの組み立て方」](appendix-prompting.md) → （Geminiなら[11章](11-gemini-advanced.md)・[12章](12-google-workspace-and-gemini.md)、Claudeなら[13章](13-claude.md)） |
+| WorkspaceのアプリでGeminiを活かしたい | [1章](01-gemini-in-workspace.md) → [8章](08-common-capabilities.md) → [11章](11-gemini-advanced.md) → [12章](12-google-workspace-and-gemini.md) |
 | 社内導入の判断材料がほしい | [2章](02-what-is-generative-ai.md) → [5章](05-misunderstanding-learning.md) → [9章](09-security-individual.md) → [10章](10-security-agent-era.md) |
 | エージェントで自動化を始めたい | [4章](04-external-system-integration.md) → [7章](07-terminology.md) → [10章](10-security-agent-era.md) → [付録「Claude Code」](appendix-claude-code.md) |
-| 画像・PDF・音声をAIに扱わせたい | [3章](03-multimodal.md) → [8章](08-common-capabilities.md) → （関心に応じて[11章](11-gemini-advanced.md)または[13章](13-claude.md)） |
+| 画像・PDF・音声をAIに扱わせたい | [3章](03-multimodal.md) → [8章](08-common-capabilities.md) → （Geminiなら[11章](11-gemini-advanced.md)・[12章](12-google-workspace-and-gemini.md)、Claudeなら[13章](13-claude.md)） |
 
 付録6本は、本編から少し離れた領域を扱います。並びは、日常業務寄り→開発寄り→技術解説寄りの順です。
 


### PR DESCRIPTION
## 概要

0章のおすすめ順路テーブル（5ルート）に、12章（Google WorkspaceとGemini）が一切含まれていなかった問題を修正します。

## 背景

- Mermaid図では「11・12章 Gemini側の使いこなし」と正しくグループ化されていたが、テキスト側のルートは「11章または13章」のみで12章に触れていなかった
- 12章はDocs・Sheets・Gmail・Meet・SlidesでのGemini統合を扱う章であり、対象読者（Google Workspaceを日常使いする非エンジニア）にとって最も実務的な章の一つ
- おすすめ順路はナビゲーションの起点にあたり、ここに12章がないと、読者が12章の存在に気づくのは11章を読み終えた時点まで遅れる

## 変更内容

- 既存3ルート（「まず使ってみたい」「依頼の出し方を上達させたい」「画像・PDF・音声をAIに扱わせたい」）のGemini側の到達点に12章を追加
- 分岐の表記を「関心に応じて11章または13章」から「Geminiなら11章・12章、Claudeなら13章」に変更し、判断基準を明示
- 対象読者向けに「WorkspaceのアプリでGeminiを活かしたい」ルートを新設（1章 → 8章 → 11章 → 12章）

## 確認事項

- `npm run lint` クリーン
- 12章の前提（11章を先に読んでいること）を尊重し、新設ルートでも11章→12章の順を維持
- Mermaid図・まとめ節との整合を確認済み

Closes #318

---
_Generated by [Claude Code](https://claude.ai/code/session_018eVsWLHutyaXGTfRPqkayw)_