### PR TITLE
docs: 00章の付録紹介リスト4項目で「の整理」連鎖を解消する

### DIFF
--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -79,10 +79,10 @@ flowchart TB
 
 - [プロンプトの組み立て方](appendix-prompting.md) — 依頼文の基本形と業務テンプレート、カスタム指示（Gems・Projects）の書き方、渡す情報の判断基準（[9章](09-security-individual.md)との接続）、応答の立て直し、音声での依頼パターン、長い会話の分割と引き継ぎ
 - [ワークフローツール](appendix-workflow-tools.md) — ZapierやMake、n8nといったSaaS連携のノーコードツールに生成AIを組み込むときの観点
-- [デスクトップの自動化](appendix-desktop-automation.md) — 自席のPC上で繰り返している手作業を生成AIに任せる選択肢の整理
-- [Claude Code](appendix-claude-code.md) — 利用者のPC上で動くClaude製品の位置づけと、ブラウザ版との違い、最初の利用方針の整理
-- [拡張検索と埋め込み検索](appendix-retrieval-and-embeddings.md) — RAG・Embedding・ベクトル検索・グラウンディングといった用語と仕組みの整理。社内文書をAIに検索させたい場面や、ベンダー提案に含まれるこれらの用語を読み解く場面で参照
-- [ローカルLLM](appendix-local-llm.md) — 提供事業者のクラウド以外で生成AIを動かす選択肢と、検討の動機の整理
+- [デスクトップの自動化](appendix-desktop-automation.md) — 自席のPC上で繰り返している手作業を生成AIに任せる選択肢
+- [Claude Code](appendix-claude-code.md) — 利用者のPC上で動くClaude製品の位置づけと、ブラウザ版との違い、最初の利用方針
+- [拡張検索と埋め込み検索](appendix-retrieval-and-embeddings.md) — RAG・Embedding・ベクトル検索・グラウンディングといった用語と仕組み。社内文書をAIに検索させたい場面や、ベンダー提案に含まれるこれらの用語を読み解く場面で参照
+- [ローカルLLM](appendix-local-llm.md) — 提供事業者のクラウド以外で生成AIを動かす選択肢と、検討時の動機
 
 本編を読み終えたあと、必要になったタイミングで参照する想定です。
 

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -82,7 +82,7 @@ flowchart TB
 - [デスクトップの自動化](appendix-desktop-automation.md) — 自席のPC上で繰り返している手作業を生成AIに任せる選択肢
 - [Claude Code](appendix-claude-code.md) — 利用者のPC上で動くClaude製品の位置づけと、ブラウザ版との違い、最初の利用方針
 - [拡張検索と埋め込み検索](appendix-retrieval-and-embeddings.md) — RAG・Embedding・ベクトル検索・グラウンディングといった用語と仕組み。社内文書をAIに検索させたい場面や、ベンダー提案に含まれるこれらの用語を読み解く場面で参照
-- [ローカルLLM](appendix-local-llm.md) — 提供事業者のクラウド以外で生成AIを動かす選択肢と、検討時の動機
+- [ローカルLLM](appendix-local-llm.md) — 提供事業者のクラウド以外で生成AIを動かす選択肢と、検討の動機
 
 本編を読み終えたあと、必要になったタイミングで参照する想定です。
 


### PR DESCRIPTION
## 変更の要点

Issue #404 横断課題 X-6（語彙の反復）のフォローアップとして、`docs/00-overview.md` 付録紹介リストの「の整理」4項目連続を解消します。

| 行 | Before | After |
|---|---|---|
| L82 | 「自席のPC上で繰り返している手作業を生成AIに任せる選択肢の整理」 | 「自席のPC上で繰り返している手作業を生成AIに任せる選択肢」 |
| L83 | 「利用者のPC上で動くClaude製品の位置づけと、ブラウザ版との違い、最初の利用方針の整理」 | 「利用者のPC上で動くClaude製品の位置づけと、ブラウザ版との違い、最初の利用方針」 |
| L84 | 「RAG・Embedding・ベクトル検索・グラウンディングといった用語と仕組みの整理。社内文書をAIに検索させたい場面や、ベンダー提案に含まれるこれらの用語を読み解く場面で参照」 | 「RAG・Embedding・ベクトル検索・グラウンディングといった用語と仕組み。社内文書をAIに検索させたい場面や、ベンダー提案に含まれるこれらの用語を読み解く場面で参照」 |
| L85 | 「提供事業者のクラウド以外で生成AIを動かす選択肢と、検討の動機の整理」 | 「提供事業者のクラウド以外で生成AIを動かす選択肢と、検討の動機」 |

## 振り分けの判断

- 同じリストの先頭2項目（L80 プロンプト「引き継ぎ」、L81 ワークフロー「観点」）は具体的な体言で終止しており、L82〜L85 の「の整理」だけが定型化していた
- リスト項目は名詞句で十分内容を運べるため、末尾の「の整理」は冗長。落としても各項目の意味は保たれる

## セルフレビューでの調整（2コミット目）

- 初コミットでは L85 を「検討時の動機」と振り替えていたが、原文「検討の動機」は「（ローカルLLMを）検討する動機」の意味で、「検討時の動機」だと「検討している時の動機」と意味がずれるため、シンプルに「の整理」だけ除去した形に戻した

## スコープ外

- 章内の他の「整理」（L15・L38・L91 の節中の動詞用法、L34 の表セル内）は独立した文脈の自然な用法のためそのまま残す
- WRITING_GUIDE.md（PR #411 と並行のため触らない）
- 参考URL・最終確認日（表現リライトは参照妥当性に影響しない編集）
- 他章・他付録の「整理」分散（前セッションの #417・#418・#419・#420・#424 などで対応済み。00章の本リストは未対応だった）

## 確認方法

```bash
npm install
npm run lint   # 警告ゼロ
```

Refs #404