### PR TITLE
docs: 11章L3の章リード段落「扱います」3連鎖を解消する（X-6 取りこぼし）

### DIFF
--- a/docs/11-gemini-advanced.md
+++ b/docs/11-gemini-advanced.md
@@ -1,6 +1,6 @@
 # 11. Geminiを使いこなそう
 
-本章は、Gemini固有の機能と、2026年5月時点で利用者が確認しておきたい制約、Gemini側に寄せたほうが進めやすい場面の3点を扱います。取り上げる機能は、Gems、保存済み情報、Canvas、マルチモーダル入力、画像生成（Imagen）、動画生成（Veo）、Deep Research、Gemini Liveの8つです。加えて、Chromeブラウザに組み込まれた呼び出し画面であるGemini in Chromeと、Chromeに同梱されたオンデバイスモデルGemini Nanoとの関係も扱います。[8章](08-common-capabilities.md)で示した「チャット／アーティファクト／コネクタ」の共通骨格に対する、Gemini側の具体像をここで扱います。
+本章は、Gemini固有の機能と、2026年5月時点で利用者が確認しておきたい制約、Gemini側に寄せたほうが進めやすい場面の3点を扱います。取り上げる機能は、Gems、保存済み情報、Canvas、マルチモーダル入力、画像生成（Imagen）、動画生成（Veo）、Deep Research、Gemini Liveの8つです。加えて、Chromeブラウザに組み込まれた呼び出し画面であるGemini in Chromeと、Chromeに同梱されたオンデバイスモデルGemini Nanoとの関係にも触れます。[8章](08-common-capabilities.md)で示した「チャット／アーティファクト／コネクタ」の共通骨格に対する、Gemini側の具体像をここで描きます。
 
 Google Workspaceの各アプリ（Docs・Sheets・Gmail・Meet・Slides）から呼び出すGemini統合は[12章](12-google-workspace-and-gemini.md)で別立てに扱います。本章はGeminiアプリ（`gemini.google.com`）、Workspaceアプリ右上のサイドパネル、およびChromeブラウザに組み込まれたGemini in Chromeから呼び出すGemini単体を対象にします。
 


### PR DESCRIPTION
## 変更の要点

Issue #404 の横断課題 X-6（語彙の反復・置換語ドリフト）のフォローアップとして、`docs/11-gemini-advanced.md` L3 の章リード段落（4文）で「扱います」が3回出現していた点を解消します。直近の PR #444 / #446 / #447 / #448 / #449 / #450 / #451 / #452 と同型の同一段落・同一語尾連鎖で、密度は今回が **3連鎖** とやや高くなっています。

| 行 | 役割 | Before | After |
|---|---|---|---|
| `docs/11-gemini-advanced.md` L3（1文目） | 章の主題提示 | 「3点を**扱います**」 | 同（保持） |
| `docs/11-gemini-advanced.md` L3（3文目） | 追加項目への言及 | 「関係も**扱います**」 | 「関係にも**触れます**」 |
| `docs/11-gemini-advanced.md` L3（4文目） | 章の位置づけ（具体像の呈示） | 「具体像をここで**扱います**」 | 「具体像をここで**描きます**」 |

各文の役割が非対称（主題提示／追加項目／位置づけ）であるにもかかわらず、3文の文末がすべて同一語尾で締まっており、章の入り口で語尾の密度が高くなっていました。

## 振り分けの判断

- **1文目を保持**: 「3点を扱います」は章全体の主題提示で、最も広いスコープを担う中核の文。ここを変えると章のリードの軸がぼやけるため保持する
- **3文目を「触れます」へ**: ChromeのGemini in ChromeとGemini Nanoは本章の主題ではなく「加えて」言及する追加項目で、軽い扱いが本来の比重と合う。「触れます」は11章内で他出なし
- **4文目を「描きます」へ**: 「Gemini側の**具体像**を…」と続く文脈で、動詞側を「描く」に揃えると名詞（具体像）と動詞（描く）の対応関係が成立する。具体例によって共通骨格を肉付けする本章の役割を、文末の動詞が支える形になる。「描きます」は11章内で他出なし

## 別案の比較（不採用とした候補）

- **「示します」**: 同文内に「[8章]で**示した**」が先行する形で並んでおり、4文目末を「示します」にすると句内連鎖になる。不採用
- **「取り上げます」**: 2文目に「**取り上げる**機能は…」があり、1文内連鎖になる。不採用
- **「見ていきます」**: 動詞として弱く、読者が章で実行する動作（読み進める）と章が運ぶ役割（具体像の呈示）が混ざる。今回の4文目は章側の役割を述べる位置で、章の動作（描く）に振るほうが対称が立つ

## スコープ外

- 11章L113 のマルチモーダル節リードに残る「扱う／扱います」連鎖（独立した節・別段落で、章リードとは別系統のため別PRに切り出す）
- L5 で12章への参照と本章対象の説明に「扱います／対象にします」が並ぶが、これは段落をまたいでおり同一段落内の隣接連鎖には該当しない
- WRITING_GUIDE.md（PR #411 と並行のため触らない）
- 並行 open PR（#432 / #440）と対象ファイル・行は重ならない
- 参考URL・最終確認日（表現リライトは参照妥当性に影響しない編集）

## 確認方法

```bash
npm install
npm run lint   # 警告ゼロを維持
```

## チェック観点

- [x] 同一段落内の「扱います」3連鎖が1か所に戻っている（1文目の主題提示のみ）
- [x] 置換語「触れます」「描きます」がいずれも11章内で新たな連鎖を生まない
- [x] 「示した」「取り上げる」との隣接連鎖を回避できている
- [x] 章のリードとしての主題提示の重みが保たれている
- [x] `npm run lint` 警告ゼロ
- [x] 「最終確認」日付を変更していない
- [x] 章を通読し、削除・置換で段落が宙に浮いた箇所がないことを確認

Refs #404

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZpFbcNSArjc3YW6NFEfxt)_