### PR TITLE
ci(lint): prh-style.yml 単独変更でも lint ワークフローを起動できるよう paths に追加する

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ on:
       - '.textlintrc.json'
       - '.markdownlint.jsonc'
       - 'prh.yml'
+      - 'prh-style.yml'
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/lint.yml'


### PR DESCRIPTION
## 変更の要点

`.github/workflows/lint.yml` の `pull_request.paths` に `prh-style.yml` を1行追加します。`.textlintrc.json` の `rules.prh.rulePaths` には `./prh.yml` と `./prh-style.yml` が並んで登録されているにもかかわらず、CI 側の paths には `prh.yml` のみが含まれており、`prh-style.yml` 単独の追加・変更ではCIの textlint・markdownlint ジョブが起動しない状態でした。

```diff
       - '.markdownlint.jsonc'
       - 'prh.yml'
+      - 'prh-style.yml'
       - 'package.json'
```

## 背景

Issue #404 の追走作業で、X-2「効果断定の語尾」・X-6「語彙の反復」などの再発防止ルールを `prh-style.yml` に蓄積する運用が確立しています（PR #439・#458・#487 ほか）。今回の paths 追加により、当該ファイル単独の変更でもCIが回り、ローカル `npm run lint` の結果と等価の検出が PR チェックの一部として残るようになります。

直前の PR #487 のセルフレビュー（[issuecomment-4709700685](https://github.com/ma2saka/docs-claude-sample/pull/487#issuecomment-4709700685)）と、Issue #404 の最新コメント（[issuecomment-4709707338](https://github.com/ma2saka/docs-claude-sample/issues/404#issuecomment-4709707338)）で「フォローアップとして workflow の paths に `prh-style.yml` を追加するPRを別立てで提案する余地がある」と明示されていた、任意項目の1点を独立PRとして起こします。

## 振り分けの判断

- 別案として paths を `**/*.yml` のような広めの指定に開く選択肢も検討しましたが、リポジトリ直下に他のYAMLが今後増えた場合（Renovate / Dependabot 設定など）に余計なlint実行が走るため不採用。1行の明示的列挙のほうが意図が読み手に伝わります
- 並びは `prh.yml` の直下に揃えました。両者がペアであることを構造的に示します
- `paths-ignore` 側への追加は不要（現在は `paths` 列挙による包含側の制御方針）
- 本PR自身も `'.github/workflows/lint.yml'` 列挙の対象に含まれているため、変更時にCIが起動します

## スコープ外

- `prh.yml`・`prh-style.yml` の中身（ルール定義の追加・調整は別PR）
- `.textlintrc.json`（参照設定は据え置き）
- WRITING_GUIDE.md（並走中の PR #411 と衝突しないように触りません）
- 参考URL・最終確認日（workflow 変更は本文の参照妥当性に影響しない編集）

## 確認方法

```bash
npm install
npm run lint   # 警告ゼロを維持
```

ローカル実行で警告ゼロを確認済みです。本PRが取り込まれて以降、`prh-style.yml` のみを編集する小さなPRでもCIの textlint・markdownlint ジョブがトリガされます。

## チェック観点

- [x] `.github/workflows/lint.yml` の `paths` に `prh-style.yml` が追加されている
- [x] 並びが `prh.yml` の直下に揃っている
- [x] `npm run lint` 警告ゼロ
- [x] 「最終確認」日付・docs本文・WRITING_GUIDE.md には触れていない
- [x] CI トリガ条件以外の workflow 内容（jobs・permissions）は据え置き

Refs #404