### PR TITLE
docs: appendix-desktop-automation L7 対象読者リストの「目を通している人」隣接連鎖を解消する（X-6 取りこぼし）

### DIFF
--- a/docs/appendix-desktop-automation.md
+++ b/docs/appendix-desktop-automation.md
@@ -4,7 +4,7 @@
 
 ## 対象読者と前提
 
-- [7章](07-terminology.md)で「エージェント」の用語に目を通している人
+- [7章](07-terminology.md)で「エージェント」の用語に目を通した人
 - [8章](08-common-capabilities.md)で生成AIの共通的な使い方を把握している人
 - [Appendix: ワークフローツール](appendix-workflow-tools.md)でSaaS連携の輪郭を確認し、自分のPC上の作業にも広げたい人
 


### PR DESCRIPTION
## 変更の要点

Issue #404 の横断課題 X-6（語彙の反復・置換語ドリフト）のフォローアップとして、`docs/appendix-desktop-automation.md` の「対象読者と前提」節（L5）の3項目リストで、隣接2行（L7 と L8）の末尾「ている人」が連鎖していた点を解消します。直近マージの PR #498（`appendix-prompting` L9 対象読者リスト）と同型の取りこぼしです。

```text
Before (3項目の末尾): 目を通している人／把握している人／広げたい人
After  (3項目の末尾): 目を通した人／把握している人／広げたい人
```

| 行 | Before | After |
|---|---|---|
| `docs/appendix-desktop-automation.md` L7 末尾 | 「[7章](07-terminology.md)で「エージェント」の用語に**目を通している人**」 | 「[7章](07-terminology.md)で「エージェント」の用語に**目を通した人**」 |

修正後は、3項目の文末（目を通した人／把握している人／広げたい人）がすべて異なる形になります。

## 振り分けの判断

- L7 は本文 L3 が前提として置く「7章でエージェントの語に一度触れた経験」を読者条件として書き起こす箇所です。完了時制「目を通した」に振り替えても、リスト全体の意味（7章を一度通読した状態を前提とする）は保たれます
- L8 の「8章で生成AIの共通的な使い方を把握している」は、8章の3本柱の使い方を理解した状態（経験ではなく内容の把握）を指す語感が強く、過去形に振り替えると意味の中心がやや弱まるため**据え置く**判断としました
- L9 の述部は「たい人」で、L7・L8 とは異なる形のため連鎖の対象外です
- 「目を通した人」は 01章L7・09章L10・appendix-claude-code L10・appendix-prompting L12 で対象読者リストの同じ用法に既出のため、新たな表現の導入にあたりません
- 別案として L8 の側を「把握した人」に振り替える選択肢もありますが、L8 のリンク先（8章）に対する本書の語感は、最近の PR #498（appendix-prompting）でも「3本柱を眺めた」と「ざっと見た」側に寄せた経緯があり、ここは過去形よりも継続状態（把握している）のほうが章間の語感に合います

## スコープ外

- 本付録の他の「ている」（L3 章リードの「広がっています」、L28 「対象に入ってきました」、L98 「組み込まれています」など）は離散しており、X-6 の隣接連鎖には該当しないため触りません
- `WRITING_GUIDE.md`（PR #411 と並行のため触らない）
- 参考URL・最終確認日（表現リライトは参照妥当性に影響しない編集）
- 並行 open の PR #411 / #432 / #440 / #475 / #478 / #480 / #494 / #496 と対象ファイル・行は重なりません

## 確認方法

```bash
npm install
npm run lint   # 警告ゼロを維持
```

## チェック観点

- [x] 隣接2項目（L7・L8）の末尾「ている人」連鎖が解消されている
- [x] 置換語「目を通した人」は本書の対象読者リストに4箇所で既出（01章/09章/appendix-claude-code/appendix-prompting）。新たな表現の導入にあたらない
- [x] 3項目の文末（目を通した人／把握している人／広げたい人）がすべて異なる
- [x] L8 を据え置いた語感の判断が章間で一貫している
- [x] `npm run lint` 警告ゼロ
- [x] 「最終確認」日付を変更していない
- [x] 章を通読し、削除・置換で段落が宙に浮いた箇所がないことを確認

Refs #404


---
_Generated by [Claude Code](https://claude.ai/code/session_019siccHMXnip2L44hvqdeQJ)_