### PR TITLE
docs: appendix-claude-code L9 対象読者リスト「した人」隣接連鎖を解消する（X-6 取りこぼし）

### DIFF
--- a/docs/appendix-claude-code.md
+++ b/docs/appendix-claude-code.md
@@ -6,7 +6,7 @@ Claude Codeは、Anthropic社のClaude製品の1つで、利用者のPC上のフ
 
 ## 対象読者と前提
 
-- [13章](13-claude.md)でブラウザ版Claudeを一通り利用した人
+- [13章](13-claude.md)でブラウザ版Claudeを一通り使った人
 - [Appendix: ワークフローツール](appendix-workflow-tools.md)で、生成AIが処理の1ステップとして動く構成に目を通した人
 - 「コードは書かないが、PC上のファイルや定型作業までAIに任せてみたい」立場の人
 


### PR DESCRIPTION
## 変更の要点

`docs/appendix-claude-code.md` の「対象読者と前提」節（L7）の3項目リストで、L9 と L10 が末尾「した人」で隣接連鎖していた点を、L9 を「一通り利用した人」→「一通り使った人」に振り替えることで解消します。

```text
Before (3項目の末尾): 利用した人／目を通した人／立場の人
After  (3項目の末尾): 使った人／目を通した人／立場の人
```

直近マージの PR #498（appendix-prompting L9「把握した人」隣接連鎖）と同型の取りこぼしです。

## 振り替えの判断

| 行 | Before | After |
|---|---|---|
| L9 末尾 | 「…ブラウザ版Claudeを一通り**利用した人**」 | 「…ブラウザ版Claudeを一通り**使った人**」 |

- L10「目を通した人」は本書の対象読者リストにおける定型表現（01章 L7・09章 L10・appendix-desktop-automation L7・appendix-prompting L12）として確立しているため、こちらは据え置く
- 「使った人」は本書全体で他出ゼロ。ただし 08章 L9「Geminiを使ったことがある人」、appendix-local-llm L16「サービスを一通り使ったうえで」と語彙が整合しており、新規語の導入にはあたらない
- 「一通り」は appendix-local-llm L16・13章 L22 で同様の用法に既出のため、述語の側だけを動かす

## 検討した別案

- 「触れた人」: 「ブラウザ版Claudeに触れた」は13章ハンズオンを通った人の体験としてはやや抽象的。13章の節（クイックスタート）と整合させるため不採用
- 「使ったことがある人」: 末尾は L10 と衝突しないが「一通り」のニュアンスが落ち、意味の幅が広くなる
- L10 側を振り替える案: 4章のリストにまたがる定型表現を動かすことになるため、章間の語感を優先して L9 側で対応

## 確認方法

- `npm run lint` 警告ゼロを確認済み
- 対象読者リスト3項目を通読し、L9・L10・L11 の末尾が分散していることを確認
- 本文 L11「立場の人」、L13 の補足段落への接続に変化がないことを確認
- WRITING_GUIDE.md・参考URL・最終確認日には触れていない

Refs #404